### PR TITLE
Remove index variable from template

### DIFF
--- a/elastic_panel/templates/elastic_panel/elastic_panel.html
+++ b/elastic_panel/templates/elastic_panel/elastic_panel.html
@@ -5,7 +5,7 @@
     <dl>
     {% for record in records %}
         <dt>
-        {{index}} {{ record.method }} {{record.status_code}} {{record.path}}  QueryHash-> {{record.hash}}
+        {{ record.method }} {{record.status_code}} {{record.path}}  QueryHash-> {{record.hash}}
         </dt>
         <dd>time: {{record.duration}} ms</dd>
         <dd>full_url: {{record.full_url}}</dd>


### PR DESCRIPTION
{{ index }} is not set (and used). Throwing exception on my more error defensive django template settings.