### PR TITLE
Fix TypeError: can't concat bytes to str

### DIFF
--- a/elastic_panel/panel.py
+++ b/elastic_panel/panel.py
@@ -39,7 +39,7 @@ class ElasticQueryInfo:
         self.status_code = status_code
         self.response = _pretty_json(response)
         self.duration = round(duration * 1000, 2)
-        self.hash = hashlib.md5(self.full_url.encode('ascii', 'ignore') + self.body).hexdigest()
+        self.hash = hashlib.md5(self.full_url.encode('ascii', 'ignore') + self.body.encode('ascii', 'ignore')).hexdigest()
 
 
 class ElasticDebugPanel(Panel):


### PR DESCRIPTION
On MacOS Python 3.6.1 elasticsearch debug toolbar raise exception TypeError: can't concat bytes to str. Traceback:

Traceback:
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/django/core/handlers/base.py" in get_response
  132.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/Users/martin.svoboda/workspace/citaty/citaty/authors/views.py" in author_detail
  32.     tag_facets = originator.get_tag_facets()
File "/Users/martin.svoboda/workspace/citaty/citaty/authors/models.py" in get_tag_facets
  156.         facet_counts = LanguageBackendSearchQuerySet().models(Quote).filter(originator_id=self.id).facet('tags', size=6).facet_counts()
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/haystack/query.py" in facet_counts
  543.             return clone.query.get_facet_counts()
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/haystack/backends/__init__.py" in get_facet_counts
  656.             self.run()
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/haystack/backends/elasticsearch_backend.py" in run
  951.         results = self.backend.search(final_query, **search_kwargs)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/haystack/backends/__init__.py" in wrapper
  32.             return func(obj, query_string, *args, **kwargs)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/haystack/backends/elasticsearch_backend.py" in search
  524.                                            _source=True)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/elasticsearch/client/utils.py" in _wrapped
  69.             return func(*args, params=params, **kwargs)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/elasticsearch/client/__init__.py" in search
  530.             doc_type, '_search'), params=params, body=body)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/elasticsearch/transport.py" in perform_request
  329.                 status, headers, data = connection.perform_request(method, url, params, body, ignore=ignore, timeout=timeout)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/elasticsearch/connection/http_urllib3.py" in perform_request
  109.             raw_data, duration)
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/elastic_panel/panel.py" in patched_log_request_success
  16.     collector.collect(ElasticQueryInfo(method, full_url, path, body, status_code, response, duration))
File "/Users/martin.svoboda/workspace/.venv/citaty/lib/python3.6/site-packages/elastic_panel/panel.py" in __init__
  44.         self.hash = hashlib.md5(self.full_url.encode('ascii', 'ignore') + self.body).hexdigest()