### PR TITLE
Added Django Debug Toolbar 1.10+ support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
 recursive-include elastic_panel/templates *
+recursive-include elastic_panel/static *

--- a/elastic_panel/static/elastic_panel/js/elastic_panel.js
+++ b/elastic_panel/static/elastic_panel/js/elastic_panel.js
@@ -1,0 +1,39 @@
+var toggle = function(elem) {
+if (window.getComputedStyle(elem).display === 'block') {
+    elem.style.display = 'none';
+    return;
+}
+
+elem.style.display = 'block';
+};
+
+var uarr = String.fromCharCode(0x25b6),
+    darr = String.fromCharCode(0x25bc);
+
+var showHandler = function(e) {
+
+    toggle(this.nextElementSibling)
+
+    arrow = document.querySelector('a.elasticShowTemplate .toggleArrow')
+    arrow.textContent = arrow.textContent == uarr ? darr : uarr
+
+    toggle(this.parentNode.nextElementSibling)
+
+    return false
+};
+
+for (var e of document.querySelectorAll('a.elasticShowTemplate')) {
+    e.addEventListener('click', showHandler)
+}
+
+var textHandler = function(e) {
+    selection = window.getSelection();
+    range = document.createRange();
+    range.selectNodeContents(this.parentNode.nextElementSibling.querySelector('code'));
+    selection.removeAllRanges();
+    selection.addRange(range);
+};
+
+for (var e of document.querySelectorAll('.selectText')) {
+    e.addEventListener('click', textHandler)
+}

--- a/elastic_panel/templates/elastic_panel/elastic_panel.html
+++ b/elastic_panel/templates/elastic_panel/elastic_panel.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load static %}
 
 {#<h4>{% trans 'Queries' %}</h4>#}
 {% if records %}
@@ -45,26 +46,4 @@
     {% endif %}
 {% endif %}
 
-<script>
-    (function ($) {
-        var uarr = String.fromCharCode(0x25b6),
-            darr = String.fromCharCode(0x25bc);
-
-        $('a.elasticShowTemplate').on('click', function() {
-            $(this).next().toggle();
-            var arrow = $(this).children('.toggleArrow');
-            arrow.html(arrow.html() == uarr ? darr : uarr);
-            textarea = $(this).parent().next();
-            textarea.toggle();
-            return false;
-        });
-
-        $('.selectText').on('click', function() {
-            $(this).parent().next().find('code').focus();
-        });
-
-        $('code.json_code').on('focus', function() {
-            document.execCommand('selectAll', false, null);
-        });
-    })(djdt.jQuery);
-</script>
+<script src="{% static 'elastic_panel/js/elastic_panel.js' %}"></script>


### PR DESCRIPTION
Replaced jQuery code with native JS because Django Debug Toolbar removed jQuery in 1.10.

Moved inline javascript to an external file, so is executed after fetching it with ajax.