### PR TITLE
Support Django debug toolbar 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 sudo: true
 
 python:
-- 2.7
 - 3.7
 - 3.6
 - 3.5
@@ -29,4 +28,4 @@ deploy:
     branch: master
     #distributions: sdist bdist_wheel
     repo: Benoss/django-elasticsearch-debug-toolbar
-    condition: $TRAVIS_PYTHON_VERSION = "2.7"
+    condition: $TRAVIS_PYTHON_VERSION = "3.7"

--- a/elastic_panel/panel.py
+++ b/elastic_panel/panel.py
@@ -69,8 +69,9 @@ class ElasticDebugPanel(Panel):
 
     def process_request(self, request):
         collector.clear_collection()
+        return super().process_request(request)
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         records = collector.get_collection()
         self.total_time = 0
         self.nb_duplicates = 0

--- a/elastic_panel/test/test_toolbar.py
+++ b/elastic_panel/test/test_toolbar.py
@@ -4,7 +4,12 @@ import unittest
 from django.conf import settings
 settings.configure()
 
+from debug_toolbar.toolbar import DebugToolbar
+from django.http import HttpResponse
+from django.test import RequestFactory
+from elasticsearch.connection import Connection
 from elastic_panel import panel
+
 
 class ImportTest(unittest.TestCase):
     def test_input(self):
@@ -13,7 +18,24 @@ class ImportTest(unittest.TestCase):
         panel.ElasticQueryInfo("GET", "asdasd", "asdasd", None, 200, "adssad", 1)
         panel.ElasticQueryInfo("GET", "asdasd", "asdasd", "{'asddsa': 'é'}", 200, "adssad", 1)
         panel.ElasticQueryInfo("GET", "asdasd", "asdasd", b"{'asddsa': 'asddasds'}", 200, "adssad", 1)
-                                                      
+
+
+class PanelTests(unittest.TestCase):
+    def setUp(self):
+        self.get_response = lambda request: HttpResponse()
+        self.request = RequestFactory().get('/')
+        self.toolbar = DebugToolbar(self.request, self.get_response)
+        self.panel = panel.ElasticDebugPanel(self.toolbar, self.get_response)
+
+    def test_recording(self, *args):
+        response = self.panel.process_request(self.request)
+        Connection().log_request_success("GET", "asdasd", "asdasd", "{}", 200, "adssad", 1)
+        self.assertIsNotNone(response)
+
+        self.panel.generate_stats(self.request, response)
+        stats = self.panel.get_stats()
+        self.assertIn('records', stats)
+        self.assertEqual(len(stats['records']), 1)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
     ],
+    tests_require=['nose', 'django-debug-toolbar', 'elasticsearch'],
     test_suite='nose.collector',
 )


### PR DESCRIPTION
This fixes compatibility with DDT 2.0:
- `process_request` returns a response
- `process_response` is replaced with `generate_stats`
- Python 2.7 removed from testing as it's no longer supported