### PR TITLE
Support Django debug toolbar 3.0

### DIFF
--- a/elastic_panel/panel.py
+++ b/elastic_panel/panel.py
@@ -1,5 +1,4 @@
-from django.conf import settings
-from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.translation import ugettext_lazy as _
 from debug_toolbar.panels import Panel
 from debug_toolbar.utils import ThreadCollector
@@ -61,20 +60,26 @@ class ElasticDebugPanel(Panel):
     nb_duplicates = 0
     nb_queries = 0
 
+    @property
     def nav_title(self):
         return _("Elastic Queries")
 
+    @property
     def nav_subtitle(self):
         default_str = "{} queries {:.2f}ms".format(self.nb_queries, self.total_time)
         if self.nb_duplicates > 0:
             default_str += " {} DUPE".format(self.nb_duplicates)
         return default_str
 
-    def url(self):
-        return ""
-
+    @property
     def title(self):
-        return self.nav_title()
+        return self.nav_title
+
+    @property
+    def scripts(self):
+        scripts = super().scripts
+        scripts.append(static("elastic_panel/js/elastic_panel.js"))
+        return scripts
 
     def process_request(self, request):
         collector.clear_collection()

--- a/elastic_panel/static/elastic_panel/js/elastic_panel.js
+++ b/elastic_panel/static/elastic_panel/js/elastic_panel.js
@@ -14,7 +14,7 @@ var showHandler = function(e) {
 
     toggle(this.nextElementSibling)
 
-    arrow = document.querySelector('a.elasticShowTemplate .toggleArrow')
+    var arrow = document.querySelector('a.elasticShowTemplate .toggleArrow')
     arrow.textContent = arrow.textContent == uarr ? darr : uarr
 
     toggle(this.parentNode.nextElementSibling)
@@ -27,8 +27,8 @@ for (var e of document.querySelectorAll('a.elasticShowTemplate')) {
 }
 
 var textHandler = function(e) {
-    selection = window.getSelection();
-    range = document.createRange();
+    var selection = window.getSelection();
+    var range = document.createRange();
     range.selectNodeContents(this.parentNode.nextElementSibling.querySelector('code'));
     selection.removeAllRanges();
     selection.addRange(range);

--- a/elastic_panel/templates/elastic_panel/elastic_panel.html
+++ b/elastic_panel/templates/elastic_panel/elastic_panel.html
@@ -45,5 +45,3 @@
         </p>
     {% endif %}
 {% endif %}
-
-<script src="{% static 'elastic_panel/js/elastic_panel.js' %}"></script>


### PR DESCRIPTION
This fixes compatibility with DDT 3.0:
- Moved script load to `ElasticDebugPanel.scripts`
- Small JavaScript fix for strict mode.