### PR TITLE
Remove pkg_resources use

### DIFF
--- a/elastic_panel/__init__.py
+++ b/elastic_panel/__init__.py
@@ -9,13 +9,12 @@ elastic_panel
 
 """
 
-import pkg_resources
+import importlib.metadata as ilm
 
 try:
-    __version__ = pkg_resources.get_distribution("django-elasticsearch-debug-toolbar").version
-except Exception:
+    __version__ = ilm.version('django-elasticsearch-debug-toolbar')
+except ilm.PackageNotFoundError:
     __version__ = "unknown"
-
 
 __title__ = "elastic_panel"
 __author__ = "Benoit Chabord"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-from distutils.core import setup
-
 from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="django-elasticsearch-debug-toolbar",


### PR DESCRIPTION
Since this package now requires Python 3.8+, we can drop the deprecated `pkg_resources` in favor of `importlib.metadata`.